### PR TITLE
Passing extra_hosts is required to use host.docker.internal on Ubuntu

### DIFF
--- a/db_ets/docker-compose.yaml
+++ b/db_ets/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
     volumes:
       - ./grafana/prometheus:/etc/prometheus
       - prom_data:/prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   grafana:
     image: grafana/grafana
     container_name: grafana


### PR DESCRIPTION
Problem found during lab.

Without this Promethious will never get data.
See: https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-host-docker-internal